### PR TITLE
Revamp COVID tracker for 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
  # COVID-19-Bosnia and Herzegovina Tracker
- This is simple program with GUI made in Python to show COVID-19 statistics in Bosnia and Herzegovina.
+This is a simple GUI program written in Python that shows COVID-19 statistics in Bosnia and Herzegovina.
+In 2025 the application has been refreshed with a modern look and now displays
+additional data such as vaccination numbers and total tests performed.
  
  ## GENERAL INFO
 :arrow_right: API USED TO BUILD THIS PROGRAM: https://github.com/disease-sh/api :arrow_left:
@@ -24,7 +26,7 @@ In your cmd / terminal run the following command:
 `python corona.py`
 
  - - - -
-:eyes: This simple program looks like this:
+:eyes: The updated 2025 program looks like this:
 
 
 ![COVID-19-BosniaAndHerzegovinaTrackerPreviewApp](https://i.imgur.com/KFoIJfl.png)

--- a/corona.py
+++ b/corona.py
@@ -4,29 +4,49 @@ from tkinter.ttk import *
 import requests
 import datetime
 
+# Additional modules for the refreshed look
+from tkinter import messagebox
+
 # GET METODA OVDJE:
 
 
 def CovidDostaviInformacije():
+    """Fetch COVID-19 data and update the labels."""
     api = 'https://disease.sh/v3/covid-19/countries/bosnia'
+    vaccine_api = (
+        'https://disease.sh/v3/covid-19/vaccine/coverage/countries/'
+        'bosnia?lastdays=1&fullData=true'
+    )
 
     json_data = requests.get(api).json()
+    vaccine_json = requests.get(vaccine_api).json()
+
     ukupno_slucajeva = str(json_data['cases'])
     ukupno_mrtvih = str(json_data['deaths'])
     umrlo_danas = str(json_data['todayDeaths'])
     aktivnih = str(json_data['active'])
     novi_slucajevi = str(json_data['todayCases'])
     ukupno_oporavljenih = str(json_data['recovered'])
+    testirano = str(json_data['tests'])
+    populacija = str(json_data['population'])
+    ukupno_vakcinisanih = str(vaccine_json['timeline'][0]['total'])
     osvjezavanje_izvresno_u = json_data['updated']
     # konvertuje u ispravno vrijeme i datum
     datum = datetime.datetime.fromtimestamp(osvjezavanje_izvresno_u/1e3)
 
-    label.config(text="Ukupno slučajeva: " + ukupno_slucajeva
-                 + "\n"+"Ukupno preminulih: " + ukupno_mrtvih
-                 + "\n"+"Ukupno aktivni slučajeva: " + aktivnih
-                 + "\n"+"Ukupno oporavljenih: " + ukupno_oporavljenih
-                 + "\n"+"Preminulih danas: " + umrlo_danas
-                 + "\n"+"Novi slučajeva: " + novi_slucajevi)
+    label.config(
+        text=(
+            "Ukupno slučajeva: " + ukupno_slucajeva
+            + "\n" + "Ukupno preminulih: " + ukupno_mrtvih
+            + "\n" + "Ukupno aktivni slučajeva: " + aktivnih
+            + "\n" + "Ukupno oporavljenih: " + ukupno_oporavljenih
+            + "\n" + "Testiranih: " + testirano
+            + "\n" + "Ukupno vakcinisanih: " + ukupno_vakcinisanih
+            + "\n" + "Preminulih danas: " + umrlo_danas
+            + "\n" + "Novi slučajeva: " + novi_slucajevi
+            + "\n" + "Populacija: " + populacija
+        )
+    )
 
     label3.config(text="Ažurirano: ")
     label2.config(text=datum)
@@ -34,8 +54,12 @@ def CovidDostaviInformacije():
 
 # GUI ZA APLIKACIJU
 canvas = tk.Tk()
-canvas.geometry("400x400")
-canvas.title("COVID-19 STATISTIKA - BIH")
+canvas.geometry("500x550")
+canvas.title("COVID-19 STATISTIKA - BIH (2025)")
+
+# Apply a modern style
+style = Style()
+style.theme_use('clam')
 
 # ZASTAVA BOSNE
 canvas.iconbitmap(
@@ -43,26 +67,34 @@ canvas.iconbitmap(
 # 'C:\Users\imeusera\Desktop\ImeFolderaGdjeSteSpremiliBosniaflag.ico\bosniaflag.ico'
 
 # font koji ćemo koristiti
-f = ("popins", 15, "bold")
+f = ("Helvetica", 15, "bold")
 
 
 # buttoni i labeli
-button = tk.Button(canvas, font=f, text="PRIKAŽI",
+button = tk.Button(canvas, font=f, text="Prikaži podatke",
                    command=CovidDostaviInformacije)
 button.pack(pady=20)
 
 # label da se pokažu podaci
-label = tk.Label(canvas, font=f)
+label = tk.Label(canvas, font=f, justify="left")
 label.pack(pady=20)
 
 
 # Prije ispisa vremena
-label3 = tk.Label(canvas, font=5)
+label3 = tk.Label(canvas, font=("Helvetica", 10, "bold"))
 label3.pack()
 
 # Ovdje se prikazuje vrijeme od kada su informacije
-label2 = tk.Label(canvas, font=8)
+label2 = tk.Label(canvas, font=("Helvetica", 9))
 label2.pack()
+
+# Load data immediately on start
 CovidDostaviInformacije()
+
+# Show about message for 2025 update
+messagebox.showinfo(
+    "COVID-19 Tracker 2025",
+    "Ažurirani prikaz podataka za 2025. godinu"
+)
 
 canvas.mainloop()


### PR DESCRIPTION
## Summary
- refresh README to mention 2025 UI
- modernize GUI, larger window and clam theme
- display vaccinations, tests and population counts
- show a 2025 welcome message

## Testing
- `python -m py_compile corona.py`


------
https://chatgpt.com/codex/tasks/task_e_68449903b044832f99daed789737f8fc